### PR TITLE
Support multi-keyword document processing

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,10 @@ Examples:
     )
     
     parser.add_argument("base_path", nargs="?", help="Base directory containing documents")
-    parser.add_argument("--keyword", help="Keyword to search for in document names")
+    parser.add_argument(
+        "--keyword",
+        help="Keyword or comma-separated keywords to search for in document names"
+    )
     parser.add_argument("--secondary-filter", help="Secondary filter (e.g., 'MIP', 'processed')")
     parser.add_argument("--commands", help="Space-separated macro commands to apply")
     parser.add_argument("--fiji-path", help="Path to Fiji executable (auto-detected if not provided)")
@@ -85,10 +88,10 @@ Examples:
             return 0
         
         if not args.base_path or not args.keyword:
-            print("Error: Both --base_path and --keyword are required for processing")
+            print("Error: Both --base_path and --keyword(s) are required for processing")
             print("Use --help for usage information")
             return 1
-        
+
         # Create processing options
         options = ProcessingOptions(
             apply_roi=args.apply_roi,
@@ -100,9 +103,15 @@ Examples:
         )
         
         # Process documents
+        keyword_input = args.keyword
+        if isinstance(keyword_input, str) and "," in keyword_input:
+            split_keywords = [kw.strip() for kw in keyword_input.split(",") if kw.strip()]
+            if split_keywords:
+                keyword_input = split_keywords
+
         result = processor.process_documents(
             base_path=args.base_path,
-            keyword=args.keyword,
+            keyword=keyword_input,
             macro_commands=args.commands,
             options=options,
             verbose=args.verbose

--- a/test_core_setup.py
+++ b/test_core_setup.py
@@ -98,11 +98,26 @@ def test_document_info():
             file_path="/test/path/image.tif",
             filename="image",
             keyword="test",
+            matched_keyword="test",
             secondary_key="MIP",
             roi_path="/test/path/roi.zip"
         )
-        
-        print(f"✅ DocumentInfo created: {doc.filename} (keyword: {doc.keyword})")
+
+        print(
+            f"✅ DocumentInfo created: {doc.filename} (keyword: {doc.keyword}, matched: {doc.matched_keyword})"
+        )
+
+        multi_doc = DocumentInfo(
+            file_path="/test/path/other_image.tif",
+            filename="other_image",
+            keyword=["alpha", "beta"],
+            matched_keyword="beta"
+        )
+
+        print(
+            "✅ DocumentInfo supports multiple keywords: "
+            f"{multi_doc.keyword} (matched: {multi_doc.matched_keyword})"
+        )
         return True
     except Exception as e:
         print(f"❌ DocumentInfo test failed: {e}")


### PR DESCRIPTION
## Summary
- extend `DocumentInfo` and core lookup logic to accept and track multiple keywords
- adjust processing workflow and CLI messaging to handle keyword lists, including comma-separated input
- expand setup tests to demonstrate DocumentInfo usage with single and multiple keywords

## Testing
- python test_core_setup.py
- python test_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d0570f7a58832ab15bfa050b7a3f51