### PR TITLE
Add separate output paths for processed images and measurements

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,6 +68,11 @@ def main() -> int:
     parser.add_argument("--apply-roi", action="store_true", help="Apply ROI files when found using the configured templates.")
     parser.add_argument("--save-processed", action="store_true", help="Save processed images using the configured suffix.")
     parser.add_argument(
+        "--save-measurements",
+        action="store_true",
+        help="Save per-document measurement CSV exports using the configured folder.",
+    )
+    parser.add_argument(
         "--suffix",
         default="processed",
         help="Suffix appended to processed filenames (default: 'processed').",
@@ -151,6 +156,7 @@ def main() -> int:
         options = ProcessingOptions(
             apply_roi=args.apply_roi,
             save_processed_files=args.save_processed,
+            save_measurements_csv=args.save_measurements,
             custom_suffix=args.suffix,
             secondary_filter=args.secondary_filter,
             measurements_folder=args.measurements_folder,

--- a/run_sample_processing.py
+++ b/run_sample_processing.py
@@ -31,6 +31,7 @@ def build_options() -> ProcessingOptions:
     return ProcessingOptions(
         apply_roi=False,
         save_processed_files=True,
+        save_measurements_csv=True,
         custom_suffix="analyzed",
         measurements_folder="Measurements",
         processed_folder="Processed",

--- a/test_core_setup.py
+++ b/test_core_setup.py
@@ -74,6 +74,7 @@ def test_processing_options():
         print(
             "✅ Default options: apply_roi="
             f"{options.apply_roi}, save_processed={options.save_processed_files}, "
+            f"save_measurements={options.save_measurements_csv}, "
             f"summary_prefix={options.measurement_summary_prefix}"
         )
 
@@ -81,6 +82,7 @@ def test_processing_options():
         custom_options = ProcessingOptions(
             apply_roi=True,
             save_processed_files=True,
+            save_measurements_csv=True,
             custom_suffix="test",
             secondary_filter="MIP",
             measurement_summary_prefix="demo",
@@ -89,6 +91,7 @@ def test_processing_options():
         print(
             "✅ Custom options: suffix='"
             f"{custom_options.custom_suffix}', filter='{custom_options.secondary_filter}', "
+            f"save_measurements={custom_options.save_measurements_csv}, "
             f"roi_templates={custom_options.roi_search_templates}"
         )
         

--- a/test_setup.py
+++ b/test_setup.py
@@ -122,7 +122,8 @@ def test_macro_builder():
             input_path="/test/input.tif",
             output_path="/test/output.tif",
             file_extension=".tif",
-            is_bioformats=False
+            is_bioformats=False,
+            measurements_path="/test/output.csv"
         )
         print("✅ ImageData created successfully")
         


### PR DESCRIPTION
## Summary
- allow `ProcessingOptions` to control per-document measurement exports via a new `save_measurements_csv` flag and ensure macros automatically receive distinct TIFF and CSV targets
- extend the macro builder to track a dedicated `measurements_path`, update command templates, and keep custom macros compatible with the new placeholder
- surface the new toggle through the CLI/sample script and refresh setup tests to cover the additional fields

## Testing
- python test_setup.py
- python test_core_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d28618f90c832a95e329436dcebb68