### PR TITLE
Avoid spawning Fiji during path validation

### DIFF
--- a/test_core_setup.py
+++ b/test_core_setup.py
@@ -142,12 +142,25 @@ def test_core_processor():
     
     try:
         from core_processor import CoreProcessor
-        
+
+        # Ensure invalid paths are rejected before attempting auto-detection
+        invalid_path = "/invalid/path/to/fiji"
+        try:
+            CoreProcessor(fiji_path=invalid_path)
+            print("❌ CoreProcessor accepted an invalid Fiji path")
+            return False
+        except RuntimeError as invalid_error:
+            if "Invalid Fiji path" in str(invalid_error):
+                print("✅ CoreProcessor rejects invalid Fiji paths")
+            else:
+                print(f"❌ Unexpected error for invalid Fiji path: {invalid_error}")
+                return False
+
         # Try to initialize processor (may fail if Fiji not found)
         try:
             processor = CoreProcessor()
             print("✅ CoreProcessor initialized successfully")
-            
+
             # Test validation
             validation = processor.validate_setup()
             print(f"✅ Validation: fiji_valid={validation['fiji_valid']}")


### PR DESCRIPTION
## Summary
- update `validate_fiji_path` to rely on filesystem checks instead of launching Fiji
- extend the core setup smoke test to ensure invalid Fiji paths raise an error during processor construction

## Testing
- pytest test_setup.py test_core_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d29ebe9bcc832a86d92eb89ec023d8