### PR TITLE
Add optional summary table creation from saved measurement CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ python main.py /data/study --keyword Control --apply-roi \
 python main.py /data/study --keyword 4MU --save-processed --suffix analyzed \
     --measurement-prefix studyA
 
+# Disable the combined summary table while still exporting per-file measurements
+python main.py /data/study --keyword 4MU --save-measurements --skip-measurement-summary
+
 # Show every built-in macro command
 python main.py --list-commands
 
@@ -103,6 +106,7 @@ python main.py --validate
 | `--measurements-folder` | Directory (under the base path) for measurement exports. |
 | `--processed-folder` | Directory (under the base path) for processed images. |
 | `--measurement-prefix` | Prefix used when saving CSV/JSON measurement summaries. |
+| `--skip-measurement-summary` | Skip creation of the combined summary table generated from saved CSV files. |
 | `--fiji-path` | Explicit path to the Fiji executable. |
 | `--verbose` | Print detailed progress, including the matched keyword for each file. |
 
@@ -128,10 +132,12 @@ processor = CoreProcessor(
 options = ProcessingOptions(
     apply_roi=True,
     save_processed_files=True,
+    save_measurements_csv=True,
     custom_suffix="analyzed",
     measurements_folder="Measurements",
     processed_folder="Processed",
     measurement_summary_prefix="studyA",
+    generate_measurement_summary=True,
     roi_search_templates=("{name}.zip", "RoiSet_{name}.zip"),
 )
 

--- a/main.py
+++ b/main.py
@@ -93,6 +93,11 @@ def main() -> int:
         help="Prefix for generated measurement summary files (CSV and JSON).",
     )
     parser.add_argument(
+        "--skip-measurement-summary",
+        action="store_true",
+        help="Disable creation of the combined measurement summary table.",
+    )
+    parser.add_argument(
         "--roi-template",
         action="append",
         help="ROI filename template using {name} as the placeholder for the document stem. Repeat or comma-separate values.",
@@ -162,6 +167,7 @@ def main() -> int:
             measurements_folder=args.measurements_folder,
             processed_folder=args.processed_folder,
             measurement_summary_prefix=args.measurement_prefix,
+            generate_measurement_summary=not args.skip_measurement_summary,
             roi_search_templates=roi_templates,
         )
 

--- a/run_sample_processing.py
+++ b/run_sample_processing.py
@@ -36,6 +36,7 @@ def build_options() -> ProcessingOptions:
         measurements_folder="Measurements",
         processed_folder="Processed",
         measurement_summary_prefix="example_study",
+        generate_measurement_summary=True,
         roi_search_templates=("{name}.roi", "{name}.zip", "RoiSet_{name}.zip"),
         secondary_filter="MIP",
     )

--- a/test_core_setup.py
+++ b/test_core_setup.py
@@ -75,7 +75,8 @@ def test_processing_options():
             "✅ Default options: apply_roi="
             f"{options.apply_roi}, save_processed={options.save_processed_files}, "
             f"save_measurements={options.save_measurements_csv}, "
-            f"summary_prefix={options.measurement_summary_prefix}"
+            f"summary_prefix={options.measurement_summary_prefix}, "
+            f"generate_summary={options.generate_measurement_summary}"
         )
 
         # Test custom options
@@ -86,12 +87,14 @@ def test_processing_options():
             custom_suffix="test",
             secondary_filter="MIP",
             measurement_summary_prefix="demo",
+            generate_measurement_summary=False,
             roi_search_templates=("{name}.roi",),
         )
         print(
             "✅ Custom options: suffix='"
             f"{custom_options.custom_suffix}', filter='{custom_options.secondary_filter}', "
             f"save_measurements={custom_options.save_measurements_csv}, "
+            f"generate_summary={custom_options.generate_measurement_summary}, "
             f"roi_templates={custom_options.roi_search_templates}"
         )
         


### PR DESCRIPTION
## Summary
- collect per-document measurement CSV exports and build a combined summary table with document metadata
- add a ProcessingOptions toggle and CLI flag to control summary generation and document the change
- update sample scripts and tests to cover the new configuration option

## Testing
- python -m compileall core_processor.py main.py run_sample_processing.py test_core_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d2bc634070832a845859e5e99ea8d6